### PR TITLE
Correct `export_tables_for_translation` path and make `build failures` fatal | P0 Fix: item 17 & 19

### DIFF
--- a/scripts/build_binary.bat
+++ b/scripts/build_binary.bat
@@ -26,9 +26,7 @@ if not exist dts_shared_binary\dts_database mkdir dts_shared_binary\dts_database
 set /A STEP+=1
 echo === Step !STEP!/%TOTAL_STEPS%!. Build React Router App ===
 call yarn build
-if errorlevel 1 (
-    echo WARNING: yarn build failed, continuing anyway...
-)
+if errorlevel 1 exit /b 1
 
 
 set /A STEP+=1

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -29,9 +29,7 @@ mkdir -p dts_shared_binary/dts_database
 
 # Step 3: Build React Router App
 next_step "Build React Router App"
-if ! yarn build; then
-  echo "WARNING: yarn build failed, continuing anyway..."
-fi
+yarn build
 
 # Step 4: Copy build folder into dts_shared_binary
 next_step "Copying build folder into dts_shared_binary"

--- a/scripts/export_tables_for_translation.ts
+++ b/scripts/export_tables_for_translation.ts
@@ -22,10 +22,7 @@ async function main() {
 	// Sort by ID
 	items.sort((a, b) => a.id.localeCompare(b.id));
 
-	// const filePath = 'app/locales/content/en.json';
-	const filePath = path.resolve(process.cwd(), "locales", "content");
-
-	// const filePath = "build/server/locales/content/en.json";
+	const filePath = path.resolve(process.cwd(), "locales", "content", "en.json");
 	const dir = dirname(filePath);
 	fs.mkdirSync(dir, { recursive: true });
 	fs.writeFileSync(filePath, JSON.stringify(items, null, 2));


### PR DESCRIPTION
## Overview
Fixes two independent script bugs identified in the P0 audit.
- **P0-17 - `scripts/export_tables_for_translation.ts`** `filePath` resolved to `locales/content` (a directory). `dirname()` then returned `locales/` instead of `locales/content/`
- **P0-19 - `scripts/build_binary.sh` + `scripts/build_binary.bat`** Both scripts explicitly caught `yarn build` failures and continued packaging whatever was in `build/

## Files changed
- `scripts/export_tables_for_translation.ts` - path fix only
- `scripts/build_binary.sh` - remove error-swallow block
- `scripts/build_binary.bat` - same fix for Windows

## Testing
- P0-17: run `yarn export_tables_for_translation` against a dev DB and verify `locales/content/en.json` is created with translation content.
- P0-19: no automated test; the fix is verified by reading the diff - a failed `yarn build` will now abort the script with a non-zero exit code instead of silently continuing.

## Notes

> **No `app/` code touched.** Safe to merge independently of other branches and changes.