### PR TITLE
Enable 'application support' in case of exception with configurable env vars | P0 Fix: item 05

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -333,7 +333,7 @@ export function ErrorBoundary() {
 									href={supportUrl ? supportUrl : `mailto:${supportEmail}`}
 									className="text-blue-600 hover:underline font-medium"
 								>
-									{supportUrl ? "Contact Us" : supportEmail}
+									Contact Us
 								</a>
 								.
 							</div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -39,7 +39,7 @@ import { Toast } from "primereact/toast";
 import RegularMenuBar from "./components/RegularMenuBar";
 import SuperAdminMenuBar from "./components/SuperAdminMenuBar";
 import InactivityWarning from "./components/InactivityWarning";
-import { isRouteErrorResponse, useRouteError } from "react-router";
+import { isRouteErrorResponse, useRouteError, useRouteLoaderData } from "react-router";
 import { Footer } from "./frontend/footer/footer";
 
 import { getUserRoleFromSession } from "~/utils/session";
@@ -144,6 +144,8 @@ export const loader = async (
 			env: {
 				CURRENCY_CODES: currencyCode,
 				DTS_INSTANCE_CTRY_ISO3: dtsInstanceCtryIso3,
+				SUPPORT_EMAIL: process.env.SUPPORT_EMAIL || "",
+				SUPPORT_URL: process.env.SUPPORT_URL || "",
 			},
 		},
 		{
@@ -270,6 +272,10 @@ export function ErrorBoundary() {
 	const error = useRouteError();
 
 	const isDev = process.env.NODE_ENV === "development";
+	// Runtime env vars unavailable client-side via process.env — must be serialised through the root loader
+	const rootData = useRouteLoaderData("root") as any;
+	const supportUrl = rootData?.env?.SUPPORT_URL || "";
+	const supportEmail = rootData?.env?.SUPPORT_EMAIL || "";
 
 	let title = "Unexpected Error";
 	let message = "Something went wrong. Please try again later.";
@@ -320,16 +326,18 @@ export function ErrorBoundary() {
 						</a>
 
 						{/* Support Contact */}
-						{/* <div className="mt-8 border-t pt-6 text-sm text-gray-600">
-							If the problem persists, please contact support at{" "}
-							<a
-								href="mailto:support@example.org"
-								className="text-blue-600 hover:underline font-medium"
-							>
-								support@example.org
-							</a>
-							.
-						</div> */}
+						{(supportUrl || supportEmail) && (
+							<div className="mt-8 border-t pt-6 text-sm text-gray-600">
+								If the problem persists, please contact support at{" "}
+								<a
+									href={supportUrl ? supportUrl : `mailto:${supportEmail}`}
+									className="text-blue-600 hover:underline font-medium"
+								>
+									{supportUrl ? "Contact Us" : supportEmail}
+								</a>
+								.
+							</div>
+						)}
 
 						{isDev && error instanceof Error && (
 							<pre className="mt-8 text-xs bg-gray-100 p-4 rounded overflow-auto border">

--- a/example.env
+++ b/example.env
@@ -36,3 +36,8 @@ AUTHENTICATION_SUPPORTED="form"
 
 # Network proxy (network has HTTP proxy rule for outbound request, HTTPS doesn't work)
 # HTTP_PROXY="URL"
+
+# Support contact shown on the error page. SUPPORT_URL takes precedence over SUPPORT_EMAIL if both are set.
+# Use SUPPORT_EMAIL for a mailto link, SUPPORT_URL for a contact page (plain or with query params).
+SUPPORT_URL="https://www.undrr.org/contact?topic=delta"
+# SUPPORT_EMAIL="support@example.com"


### PR DESCRIPTION
## Summary
- Removes the commented and hardcoded `support@example.org` placeholder from the `ErrorBoundary` in `app/root.tsx`.
- Introduces two optional env vars: `SUPPORT_URL` and `SUPPORT_EMAIL` - giving deployers flexibility to configure a contact page URL, a parameterized URL (e.g. `?topic=delta&inst=BEL`), or a mailto link.
- `SUPPORT_URL` takes precedence if both are set; the support contact block is hidden entirely if neither is configured.
 
## Files changed 
- `app/root.tsx` - added `SUPPORT_URL` / `SUPPORT_EMAIL` to root loader `env` object                     
- `example.env` - added variables with default value and usage comments

## Test plan and unit tests performed
- [x] Set only `SUPPORT_URL` in `.env` -> ErrorBoundary shows "Contact Us" as a hyperlink to the URL
- [x] Set only `SUPPORT_EMAIL` in `.env` -> ErrorBoundary shows "Contact Us" as a `mailto:` link
- [x] Set neither -> support contact block is not rendered
- [x] `yarn tsc --noEmit` passes clean
 
#### Test Set-Up
-  An exception was thrown using code to test this out in Local Dev environment.

## Design notes

> **Why two vars:** An open-source multi-tenant product needs to support different deployment scenarios -a dedicated support email, a plain contact page, or a URL with static query params.

> **Why `useRouteLoaderData` instead of `process.env`:** Runtime env vars are not available client-side via `process.env` in this app (Vite substitutes only build-time vars).

## ⚠️ Out of scope
Translations are not implemented for the ErrorBoundary support contact text. The ErrorBoundary renders its own `<html>` document that does not include the translation script injection.

## Unit testing evidences
<img width="1649" height="996" alt="image" src="https://github.com/user-attachments/assets/d79adb19-3561-419e-8a7a-40aaef13adf7" />