### PR TITLE
Fix misplaced type exports and circular schema dependency | P0 Fix: item 10 

### DIFF
--- a/app/backend.server/models/disaster_record.ts
+++ b/app/backend.server/models/disaster_record.ts
@@ -2,7 +2,7 @@ import { dr, Tx } from "~/db.server";
 import { sectorDisasterRecordsRelationTable } from "~/drizzle/schema/sectorDisasterRecordsRelationTable";
 import { nonecoLossesTable } from "~/drizzle/schema/nonecoLossesTable";
 import { disasterRecordsTable } from "~/drizzle/schema/disasterRecordsTable";
-import { SelectDisasterRecords } from "~/drizzle/schema/hipHazardTable";
+import { SelectDisasterRecords } from "~/drizzle/schema/disasterRecordsTable";
 import { lossesTable } from "~/drizzle/schema/lossesTable";
 import { damagesTable } from "~/drizzle/schema/damagesTable";
 import { disruptionTable } from "~/drizzle/schema/disruptionTable";

--- a/app/drizzle/schema/disasterRecordsTable.ts
+++ b/app/drizzle/schema/disasterRecordsTable.ts
@@ -66,6 +66,9 @@ export const disasterRecordsTable = pgTable(
 	}),
 );
 
+export type SelectDisasterRecords = typeof disasterRecordsTable.$inferSelect;
+export type InsertDisasterRecords = typeof disasterRecordsTable.$inferInsert;
+
 export const disasterRecordsRel = relations(
 	disasterRecordsTable,
 	({ one, many }) => ({

--- a/app/drizzle/schema/hipHazardTable.ts
+++ b/app/drizzle/schema/hipHazardTable.ts
@@ -2,8 +2,6 @@ import { relations } from "drizzle-orm";
 import { pgTable, text, AnyPgColumn } from "drizzle-orm/pg-core";
 import { zeroText, zeroStrMap } from "../../utils/drizzleUtil";
 import { hipClusterTable } from "./hipClusterTable";
-import { disasterRecordsTable } from "./disasterRecordsTable";
-
 // examples:
 // MH0004,Flood,Coastal Flood
 // GH0001,Seismogenic (Earthquakes),Earthquake
@@ -29,5 +27,3 @@ export const hipHazardRel = relations(hipHazardTable, ({ one }) => ({
  * may be revised to align with new requirements and ensure data integrity.
  */
 
-export type SelectDisasterRecords = typeof disasterRecordsTable.$inferSelect;
-export type InsertDisasterRecords = typeof disasterRecordsTable.$inferInsert;

--- a/app/routes/$lang+/api+/disaster-record+/add.ts
+++ b/app/routes/$lang+/api+/disaster-record+/add.ts
@@ -7,7 +7,7 @@ import { fieldsDefApi } from "~/frontend/disaster-record/form";
 import { disasterRecordsCreate } from "~/backend.server/models/disaster_record";
 import { ActionFunction, ActionFunctionArgs } from "react-router";
 import { apiAuth } from "~/backend.server/models/api_key";
-import { SelectDisasterRecords } from "~/drizzle/schema/hipHazardTable";
+import { SelectDisasterRecords } from "~/drizzle/schema/disasterRecordsTable";
 import { BackendContext } from "~/backend.server/context";
 
 export const loader = authLoaderApi(async () => {

--- a/app/routes/$lang+/api+/disaster-record+/update.ts
+++ b/app/routes/$lang+/api+/disaster-record+/update.ts
@@ -8,7 +8,7 @@ import { disasterRecordsUpdate } from "~/backend.server/models/disaster_record";
 import { ActionFunctionArgs } from "react-router";
 import { apiAuth } from "~/backend.server/models/api_key";
 
-import { SelectDisasterRecords } from "~/drizzle/schema/hipHazardTable";
+import { SelectDisasterRecords } from "~/drizzle/schema/disasterRecordsTable";
 import { BackendContext } from "~/backend.server/context";
 
 export const loader = authLoaderApi(async () => {

--- a/app/routes/$lang+/api+/disaster-record+/upsert.ts
+++ b/app/routes/$lang+/api+/disaster-record+/upsert.ts
@@ -12,7 +12,7 @@ import {
 import { fieldsDefApi } from "~/frontend/disaster-record/form";
 import { apiAuth } from "~/backend.server/models/api_key";
 import { ActionFunction, ActionFunctionArgs } from "react-router";
-import { SelectDisasterRecords } from "~/drizzle/schema/hipHazardTable";
+import { SelectDisasterRecords } from "~/drizzle/schema/disasterRecordsTable";
 import { FormInputDef } from "~/frontend/form";
 import { BackendContext } from "~/backend.server/context";
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                              
- `SelectDisasterRecords` and `InsertDisasterRecords` were exported from `hipHazardTable.ts` despite being inferred from `disasterRecordsTable`.
- Removes an unintentional circular import: `hipHazardTable` => `disasterRecordsTable` => `hipHazardTable`
- All 4 consumers updated to import from the correct source file

## Files changed
- `app/drizzle/schema/disasterRecordsTable.ts` - added `SelectDisasterRecords` + `InsertDisasterRecords` exports
- `app/drizzle/schema/hipHazardTable.ts` - removed cross-table import and misplaced type exports
- `app/backend.server/models/disaster_record.ts` - updated import path
- `app/routes/$lang+/api+/disaster-record+/add.ts` - updated import path
- `app/routes/$lang+/api+/disaster-record+/upsert.ts` - updated import path
- `app/routes/$lang+/api+/disaster-record+/update.ts` - updated import path

## Test plan
  1. `yarn tsc --noEmit` - **passes clean**.
  2. No unit tests required - this is a type location correction with no runtime behavior change

## Notes
> ⚠️  `InsertDisasterRecords` had no consumers at the time of this fix. It has been moved to the correct file but remains unused - a separate clean-up task if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal database schema type definitions for improved code structure. No changes to user-facing functionality or API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->