### PR TITLE
Fix: P0-2 - Missing await in `deleteByIdForStringId` with SDD/TDD and Agent Improvements

### DIFF
--- a/.github/agents/sdd-implementer.agent.md
+++ b/.github/agents/sdd-implementer.agent.md
@@ -26,6 +26,10 @@ do not declare done until every quality gate passes.
 Work through `tasks.md` in the specified order. Each task should be small and independently
 verifiable. After each task, run the relevant test to confirm progress.
 
+**If tasks.md includes test-writing tasks and no test file exists yet:** invoke the
+`tdd-test-writer` agent first. Do not begin the Green phase until failing tests exist and are
+confirmed to fail for the right reason.
+
 ## Green phase
 
 - Write the minimum code that makes the failing tests pass
@@ -69,4 +73,6 @@ new tests under `tests/` using Vitest.
 
 ## Done criteria
 
-All seven gates pass and `yarn test:run2` (full PGlite suite) shows no regressions.
+All seven gates pass, `yarn test:run2` (full PGlite suite) shows no regressions, and
+`opsx:archive` has been run to move the change artifacts to `openspec/changes/archive/`.
+Archive on the same branch as a final commit before raising the PR — no separate branch needed.

--- a/.github/agents/sdd-implementer.agent.md
+++ b/.github/agents/sdd-implementer.agent.md
@@ -13,6 +13,23 @@ implement a change from its OpenSpec proposal and failing tests, then refactor t
 meets the quality bar of a principal engineer. You run the full **Green → Refactor** loop and
 do not declare done until every quality gate passes.
 
+## Guardrails
+
+**Additive edits — proceed freely.** `proposal.md` lists anticipated files but implementation
+may require others. If you edit an unlisted file, state the file, reason, and intent before
+doing so. Create as many test files under `tests/` as the change needs.
+
+**Destructive actions — stop and get explicit user approval every time:**
+- Deleting or renaming any file you did not create in this change
+- Any DB schema change not listed as a `yarn dbsync` task in `tasks.md`
+- Commands: `rm`, `git reset --hard`, `git clean -f`, `drizzle-kit push`, `DROP TABLE`,
+  `TRUNCATE`, `DELETE FROM` without a `WHERE` clause
+- Overwriting `.env`, `*.key`, `*.pem`, or any file in `app/drizzle/migrations/`
+
+**When in doubt — stop and ask.** Pausing costs seconds; an unrecoverable action costs far more.
+
+---
+
 ## Your responsibilities
 
 1. Read the OpenSpec artifacts from `openspec/changes/<name>/` — proposal, specs, design, tasks.

--- a/.github/agents/spec-writer.agent.md
+++ b/.github/agents/spec-writer.agent.md
@@ -12,6 +12,13 @@ You are a principal software engineer on the DELTA Resilience project. Your role
 a developer's intent into a complete, accurate OpenSpec proposal that any developer or AI agent
 can implement without needing to ask clarifying questions.
 
+## Before you start
+
+If the intent is vague, the problem space is ambiguous, or multiple approaches need comparing
+before a proposal can be written — run `opsx:explore` first. Explore is a thinking-partner mode
+that clarifies requirements without committing to artifacts. Once the intent is clear, return
+here and proceed from Phase 0.
+
 ## Phase 0 — Validate the intent (mandatory, always run first)
 
 Before generating any artifact or running any OpenSpec command, read the actual code and

--- a/.github/agents/spec-writer.agent.md
+++ b/.github/agents/spec-writer.agent.md
@@ -1,16 +1,29 @@
 ---
 name: spec-writer
-description: "Generates an OpenSpec proposal for a described intent in the DELTA codebase.
-  Trigger when: the user describes a fix, feature, or refactor they want to make and asks
-  for a spec, proposal, or wants to use /opsx:propose. Knows DELTA's architecture, conventions,
-  and the OpenSpec artifact format (proposal → specs → design → tasks)."
+description: "Uses the OpenSpec CLI to generate a specification proposal for a described intent
+  in the DELTA codebase. Trigger when: the user describes a fix, feature, or refactor they want
+  to make and asks for a spec, proposal, or wants to use /opsx:propose. Produces OpenSpec
+  artifacts only — never touches source files in app/."
 ---
 
 # Spec Writer Agent
 
 You are a principal software engineer on the DELTA Resilience project. Your role is to translate
-a developer's intent into a complete, accurate OpenSpec proposal that any developer or AI agent
-can implement without needing to ask clarifying questions.
+a developer's intent into a complete, accurate OpenSpec proposal using the OpenSpec CLI.
+
+## Your role boundary — read this first
+
+**You write specification artifacts. You do NOT implement fixes.**
+
+- Do NOT edit any file under `app/`, `tests/`, `scripts/`, or anywhere outside `openspec/changes/`
+- Do NOT suggest or apply code changes to source files
+- Do NOT run `yarn`, `tsc`, or any implementation command
+- You are finished when all OpenSpec artifacts are written — not when the fix is applied
+
+If you find yourself about to edit `common.ts`, `routes/`, or any source file — stop.
+That is the `sdd-implementer` agent's job, triggered by `/opsx:apply` after human review.
+
+---
 
 ## Before you start
 
@@ -19,10 +32,12 @@ before a proposal can be written — run `opsx:explore` first. Explore is a thin
 that clarifies requirements without committing to artifacts. Once the intent is clear, return
 here and proceed from Phase 0.
 
+---
+
 ## Phase 0 — Validate the intent (mandatory, always run first)
 
-Before generating any artifact or running any OpenSpec command, read the actual code and
-answer these four questions out loud:
+Before running any OpenSpec command, read the actual code and answer these four questions
+out loud:
 
 1. **What does this area of the codebase currently do?** Read the files most likely affected.
    Do not rely on the intent description alone — the description may be outdated.
@@ -41,15 +56,31 @@ genuinely needed.
 
 ---
 
-## Phase 1 — Generate artifacts
+## Phase 1 — Generate artifacts using the OpenSpec CLI
 
-1. Read the intent carefully and identify: the problem being solved, the files affected, and
-   the observable behaviour change.
-2. Run `openspec new change "<kebab-case-name>"` to scaffold the change.
-3. Run `openspec instructions <artifact> --change "<name>" --json` for each artifact in sequence
-   and generate the artifact files using the template provided.
-4. Ensure every artifact is grounded in the actual codebase — read the relevant files before
-   writing specs or design. Do not write specs based on assumptions.
+**Your first terminal action must be:**
+```bash
+openspec new change "<kebab-case-name>"
+```
+
+This creates the scaffolded change at `openspec/changes/<name>/`. Do not create or write any
+artifact file before running this command.
+
+**Then for each artifact, get its instructions from the CLI:**
+```bash
+openspec instructions <artifact> --change "<name>" --json
+```
+
+Use the `outputPath`, `template`, and `instruction` fields from the JSON response to write
+each artifact file. Work through artifacts in dependency order: `proposal` first, then
+`design` and `specs` in parallel, then `tasks` last.
+
+**Verify each artifact exists before moving to the next:**
+```bash
+openspec status --change "<name>" --json
+```
+
+Proceed only when all artifacts required for apply (`applyRequires`) show `status: "done"`.
 
 ## Artifact quality standards
 
@@ -75,8 +106,20 @@ genuinely needed.
 **tasks.md**
 - Ordered by TDD: failing test first, then implementation, then refactor
 - Each task is independently executable with `yarn vitest run path/to/test.ts`
+- Test files use `*.test.ts` naming — never `*_test.ts`
+- Setup import: `import "./setup"` for files in `tests/integration/db/`;
+  `import "../setup"` for files in subdirectories (e.g. `tests/integration/db/queries/`)
 - Final tasks always include: `yarn tsc`, `yarn format:check`
 - DB migrations listed explicitly as `yarn dbsync` — never drizzle-kit push
+
+## Done condition
+
+You are done when:
+1. `openspec status --change "<name>"` shows all artifacts complete
+2. You have summarised what was generated and what the implementer needs to do next
+3. You have NOT touched any source file outside `openspec/changes/`
+
+Hand off with: "Artifacts complete. Run `/opsx:apply` to begin implementation."
 
 ## Project context (always apply)
 

--- a/.github/agents/tdd-test-writer.agent.md
+++ b/.github/agents/tdd-test-writer.agent.md
@@ -28,7 +28,10 @@ as the tests exist and are confirmed to fail.
 - All new tests go under `tests/` — never in `app/backend.server/models/*_test.ts` (orphaned)
 - Integration tests that need a DB: use PGlite setup from `tests/integration/db/setup.ts`
 - Use `createTestBackendContext()` for backend context in tests
-- Name test files: `tests/unit/<module>.test.ts` or `tests/integration/<module>.test.ts`
+- Name test files: `tests/unit/<module>.test.ts` or `tests/integration/db/<module>.test.ts`
+  — always `*.test.ts`, never `*_test.ts` (Vitest only picks up `*.test.{ts,tsx}`)
+- Setup import: `import "./setup"` for files directly in `tests/integration/db/`;
+  `import "../setup"` for files in a subdirectory (e.g. `tests/integration/db/queries/`)
 - Test names must describe observable behaviour: `"deleteByIdForStringId throws when row does not exist"`
   not `"test deleteById"` — so failures are self-documenting
 

--- a/_docs/workflows/openspec.md
+++ b/_docs/workflows/openspec.md
@@ -17,26 +17,43 @@ cloning.
 
 ## The workflow
 
-Every change follows four steps:
+Every change follows these steps:
 
 ```
+0. /opsx:explore  →  (optional) clarify a vague intent before proposing
 1. /opsx:propose  →  spec artifacts generated in openspec/changes/<name>/
 2. Review         →  human reviews proposal.md, specs/, design.md, tasks.md
-3. /opsx:apply    →  implementation (TDD: Red → Green → Refactor)
-4. /opsx:archive  →  change closed, delta specs merged into openspec/specs/
+3. /opsx:apply    →  implementation (TDD: Red → Green → Refactor → archive)
+4. Raise PR       →  artifacts are already archived on the branch
 ```
 
 Never skip the review step between propose and apply. The spec is a checkpoint, not a formality.
+
+## Step 0 — Explore (optional)
+
+Use this when the intent is vague, the problem space is ambiguous, or you need to compare
+approaches before committing to a proposal.
+
+```
+/opsx:explore "I think there's a performance issue in the analytics queries"
+```
+
+Explore is a thinking-partner mode — it investigates and clarifies requirements without generating
+implementation artifacts. Once the intent is clear, proceed to propose.
+
+Skip this step when the intent is already well-understood.
 
 ## Step 1 — Propose
 
 Describe your intent to your AI assistant and invoke:
 
 ```
-/opsx:propose "fix deleteByIdForStringId to await the delete and throw on not-found"
+/opsx:propose "fix deleteByIdForStringId to await the select and throw on not-found"
 ```
 
-The `spec-writer` agent picks this up. It reads the relevant source files, then generates:
+The `spec-writer` agent picks this up. It first runs **Phase 0** — reading the actual source files
+to validate the intent is still needed and hasn't already been resolved. If the change is confirmed
+necessary, it generates:
 
 | Artifact | Purpose |
 |---|---|
@@ -64,33 +81,50 @@ Amend the files directly if anything is wrong. They are plain Markdown.
 /opsx:apply
 ```
 
-Three agents run in sequence:
+The `sdd-implementer` agent runs the full TDD loop:
 
-1. **`tdd-test-writer`** — writes failing Vitest tests from the spec (Red phase only). Stops here.
-2. *(human confirms tests fail for the right reason)*
-3. **`sdd-implementer`** — makes tests pass (Green), then runs the 7-gate Refactor loop until
-   all quality checks pass: tests green → tsc → format → anti-patterns → SOLID → docs → conventions.
+1. **Red phase** — invokes `tdd-test-writer` to write failing Vitest tests from the spec.
+   Confirms tests fail specifically because the behaviour doesn't yet exist (not due to import
+   errors or setup issues). *(Recommended: verify the failure reason yourself before proceeding.)*
+2. **Green phase** — writes the minimum code to make the failing tests pass.
+3. **Refactor loop** — runs 7 quality gates in order. If any gate fails, refactors and re-runs
+   from that gate. Exits only when all pass:
 
-The `solid-reviewer` agent is invoked by `sdd-implementer` during the SOLID gate.
+   | Gate | Check |
+   |---|---|
+   | 1 | `yarn vitest run` — tests still green |
+   | 2 | `yarn tsc` — zero TypeScript errors |
+   | 3 | `yarn format:check` — Prettier clean |
+   | 4 | Anti-pattern review — `.github/skills/anti-pattern-check.md` |
+   | 5 | SOLID review — `solid-reviewer` agent (SRP and DIP focus) |
+   | 6 | Documentation review — comments explain WHY, not WHAT |
+   | 7 | Project conventions — `.github/copilot-instructions.md` |
 
-## Step 4 — Archive
+4. **Archive** — runs `opsx:archive` as the final step on the branch (see below).
+
+## Step 4 — Archive and raise PR
+
+`opsx:archive` is the last commit on the implementation branch, before the PR is raised:
 
 ```
 /opsx:archive
 ```
 
-Merges the change's delta specs into `openspec/specs/`, moves the change folder to
-`openspec/archive/`, and closes the change. Run this after the PR is merged.
+This merges the change's delta specs into `openspec/specs/`, moves the change folder to
+`openspec/changes/archive/`, and closes the change. No separate branch needed — the archived
+artifacts travel with the implementation in the same PR.
+
+After archiving, raise the PR targeting `dev` as normal.
 
 ## Agents and skills reference
 
 | File | Role |
 |---|---|
-| `.github/agents/spec-writer.agent.md` | Generates OpenSpec proposal from intent |
-| `.github/agents/tdd-test-writer.agent.md` | Writes failing tests (Red phase) |
-| `.github/agents/sdd-implementer.agent.md` | Green → Refactor loop with quality gates |
+| `.github/agents/spec-writer.agent.md` | Phase 0 intent validation + OpenSpec proposal generation |
+| `.github/agents/tdd-test-writer.agent.md` | Writes failing tests (Red phase) — invoked by sdd-implementer |
+| `.github/agents/sdd-implementer.agent.md` | Orchestrates Red → Green → 7-gate Refactor → archive |
 | `.github/agents/test-writer.agent.md` | Comprehensive test suites (all tiers, independent of TDD cycle) |
-| `.github/agents/solid-reviewer.agent.md` | SOLID design review (SRP and DIP focus) |
+| `.github/agents/solid-reviewer.agent.md` | SOLID design review — invoked by sdd-implementer at gate 5 |
 | `.github/skills/tdd-cycle.md` | TDD Red→Green→Refactor methodology and DELTA tooling |
 | `.github/skills/anti-pattern-check.md` | Quality gate checklist — run before every PR |
 
@@ -98,13 +132,13 @@ Merges the change's delta specs into `openspec/specs/`, moves the change folder 
 
 ```bash
 # List all active changes
-npx @fission-ai/openspec list
+openspec list
 
 # Check artifact status for a change
-npx @fission-ai/openspec status --change "<name>"
+openspec status --change "<name>"
 
-# View a change
-npx @fission-ai/openspec show --change "<name>"
+# View apply instructions for a change
+openspec instructions apply --change "<name>"
 
 # Run a single test file
 yarn vitest run tests/path/to/file.test.ts
@@ -115,8 +149,9 @@ yarn test:run2
 # Type check
 yarn tsc
 
-# Format check
+# Format check / fix
 yarn format:check
+yarn format
 ```
 
 ## When not to use OpenSpec

--- a/app/backend.server/models/common.ts
+++ b/app/backend.server/models/common.ts
@@ -49,10 +49,15 @@ export function selectTranslated<T extends string>(
 }
 
 export async function deleteByIdForStringId(idStr: string, table: any) {
-	let id = idStr;
+	const id = idStr;
 	await dr.transaction(async (tx) => {
-		const existingRecord = tx.select({}).from(table).where(eq(table.id, id));
-		if (!existingRecord) {
+		// Execute the select so we get rows back, not a query builder object
+		const existingRecord = await tx
+			.select({ id: table.id })
+			.from(table)
+			.where(eq(table.id, id))
+			.execute();
+		if (existingRecord.length === 0) {
 			throw new Error(`Record with ID ${id} not found`);
 		}
 		await tx.delete(table).where(eq(table.id, id));

--- a/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/design.md
+++ b/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`deleteByIdForStringId` in `app/backend.server/models/common.ts` is the shared delete helper
+used by five models: `organizationDeleteById`, `nonecoLossesDeleteById`,
+`deleteRecordsDeleteById`, `disRecSectorsDeleteById`, and `assetDeleteById`. The function
+wraps a Drizzle transaction that is supposed to verify the record exists before deleting it.
+
+**Current buggy implementation (lines 51–60):**
+
+```typescript
+export async function deleteByIdForStringId(idStr: string, table: any) {
+	let id = idStr;
+	await dr.transaction(async (tx) => {
+		const existingRecord = tx.select({}).from(table).where(eq(table.id, id));
+		if (!existingRecord) {
+			throw new Error(`Record with ID ${id} not found`);
+		}
+		await tx.delete(table).where(eq(table.id, id));
+	});
+}
+```
+
+Two bugs on the same line:
+
+1. `tx.select({}).from(table).where(eq(table.id, id))` is **not awaited** — it returns a
+   Drizzle `SelectBuilder` object, which is always truthy.
+2. The guard `if (!existingRecord)` is wrong — even with `await`, an empty result is returned
+   as `[]` (an empty array), which is also truthy in JavaScript.
+
+The combined effect: the delete always proceeds, silently returning success regardless of
+whether the target row exists (documented as P0-2).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `deleteByIdForStringId` MUST throw when no row with the given `id` exists in the table.
+- `deleteByIdForStringId` MUST delete and resolve without error when the row does exist.
+- All five callers must continue to work without modification.
+
+**Non-Goals:**
+
+- No changes to other `deleteById` functions (`damagesDeleteById`, `lossesDeleteById`,
+  `disruptionDeleteById`, `disasterRecordsDeleteById`) — they are already correct.
+- No changes to callers.
+- No DB migration — this is a logic-only fix.
+- No changes to types or exported interfaces.
+
+## Decisions
+
+### Fix the existence check in a single line
+
+**Decision**: Add `await` + `.execute()` on the select call, and change the guard to
+`existingRecord.length === 0`.
+
+The `.execute()` call is idiomatic in this codebase (see `damagesDeleteById`,
+`lossesDeleteById`). The length check is the standard pattern for "no rows returned" across
+all model files.
+
+**Alternative considered**: Replace the pre-check with a post-check (inspect rows deleted).
+Drizzle's `delete().returning()` could return the deleted row, and we could throw if the
+result is empty. Rejected — it would be a larger change than the minimum needed, and
+`.returning()` is not consistently used elsewhere in this file.
+
+### Keep the transaction wrapper
+
+The transaction is preserved because the select + delete should be atomic. Removing it would
+be an unnecessary scope change.
+
+### No TypeScript type changes
+
+The function signature `(idStr: string, table: any) => Promise<void>` remains unchanged.
+The fix is purely internal.
+
+## Risks / Trade-offs
+
+- **[Risk] Callers that silently ignored failed deletes** will now throw. Mitigation: all
+  five callers already `await` the function and propagate errors through Drizzle transactions
+  — they will now correctly surface errors rather than swallowing them. This is the desired
+  behaviour.
+- **[Risk] PGlite support** — PGlite is used in the integration test suite. The `.execute()`
+  call is supported by the PGlite Drizzle adapter, so no test infrastructure changes are
+  required.
+
+## Migration Plan
+
+No deployment steps or rollback strategy needed — this is a single-function logic fix with
+no schema changes and no API contract changes.

--- a/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/proposal.md
+++ b/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`deleteByIdForStringId` in `app/backend.server/models/common.ts` silently succeeds when
+deleting a non-existent record because the existence check is never awaited. The Drizzle
+query builder object returned without `await` is always truthy, so the guard
+`if (!existingRecord)` never throws. This means callers receive no error when attempting to
+delete a record that does not exist (P0-2).
+
+## What Changes
+
+- **`app/backend.server/models/common.ts`** — Fix `deleteByIdForStringId`: add `await` and
+  `.execute()` to the `tx.select()` call, and correct the existence guard from
+  `if (!existingRecord)` to `if (existingRecord.length === 0)`.
+
+No other models are affected. All other `deleteById` functions (`damagesDeleteById`,
+`lossesDeleteById`, `disruptionDeleteById`, `disasterRecordsDeleteById`) already correctly
+await their queries.
+
+No DB migration is required — this is a logic-only fix.
+
+## Capabilities
+
+### New Capabilities
+
+- `delete-by-id-correct-existence-check`: `deleteByIdForStringId` MUST throw an error when
+  no row with the given `id` exists in the target table, and MUST delete the row and resolve
+  without error when the row does exist.
+
+### Modified Capabilities
+
+_(none — no existing spec files exist in openspec/specs/)_
+
+## Impact
+
+- **`app/backend.server/models/common.ts`** — single-line logic fix to `deleteByIdForStringId`
+- **Callers** (organization, noneco_losses, disaster_record__sectors x2, asset): all already
+  `await` the helper, so no caller changes needed
+- **Security / multi-tenancy**: no auth or tenant-scope changes required
+- **Tests**: new PGlite integration test in `tests/integration/db/queries/common.test.ts`

--- a/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/specs/delete-by-id-correct-existence-check/spec.md
+++ b/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/specs/delete-by-id-correct-existence-check/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: deleteByIdForStringId throws when record does not exist
+`deleteByIdForStringId` in `app/backend.server/models/common.ts` SHALL throw an `Error`
+when no row with the given `id` exists in the target table. The error MUST be thrown from
+within the transaction before any delete is attempted.
+
+#### Scenario: Delete is called with an ID that does not exist in the table
+- **WHEN** `deleteByIdForStringId` is called with a string ID that has no matching row in
+  the target table
+- **THEN** the function SHALL throw an `Error` (reject the returned Promise)
+
+### Requirement: deleteByIdForStringId deletes the row when it exists
+`deleteByIdForStringId` in `app/backend.server/models/common.ts` SHALL delete the matching
+row and resolve without error when a row with the given `id` exists in the target table.
+
+#### Scenario: Delete is called with an ID that exists in the table
+- **WHEN** `deleteByIdForStringId` is called with a string ID that has a matching row in
+  the target table
+- **THEN** the function SHALL resolve without error
+- **AND** the row with that ID SHALL no longer exist in the table after the call
+
+### Requirement: Callers of deleteByIdForStringId require no changes
+All five direct callers of `deleteByIdForStringId` (`organizationDeleteById`,
+`nonecoLossesDeleteById`, `deleteRecordsDeleteById`, `disRecSectorsDeleteById`,
+`assetDeleteById`) SHALL continue to compile and behave correctly without modification.
+
+#### Scenario: Caller invokes deleteByIdForStringId for a row that exists
+- **WHEN** a caller such as `organizationDeleteById` calls `deleteByIdForStringId` with the
+  ID of an existing row
+- **THEN** the caller SHALL receive a resolved Promise (no error thrown)
+
+#### Scenario: Caller invokes deleteByIdForStringId for a row that does not exist
+- **WHEN** a caller such as `organizationDeleteById` calls `deleteByIdForStringId` with an
+  ID that has no matching row
+- **THEN** the caller SHALL receive a rejected Promise (an Error is thrown)

--- a/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/tasks.md
+++ b/openspec/changes/archive/2026-04-29-fix-delete-by-id-missing-await/tasks.md
@@ -1,0 +1,34 @@
+## 1. Failing Tests (Red Phase)
+
+- [x] 1.1 Create `tests/integration/db/queries/common.test.ts` with a `describe("deleteByIdForStringId")` block:
+  - Import `"../setup"` at the top
+  - Import `deleteByIdForStringId` from `~/backend.server/models/common`
+  - Import `organizationTable` from `~/drizzle/schema` (use as the target table)
+  - Test: calling `deleteByIdForStringId` with a non-existent ID **rejects** (throws)
+  - Test: calling `deleteByIdForStringId` with an ID that was just inserted **resolves** and
+    the row is gone afterwards
+  - Run with `yarn vitest run tests/integration/db/queries/common.test.ts` — tests MUST fail
+    (Red) before the fix is applied
+
+## 2. Fix the Bug
+
+- [x] 2.1 In `app/backend.server/models/common.ts`, update `deleteByIdForStringId`:
+  - Add `await` and `.execute()` to the `tx.select({})` call so it returns `{ id: string }[]`
+    (or just select a minimal column — use `{ id: table.id }` rather than empty `{}` to get
+    a useful value)
+  - Change the guard from `if (!existingRecord)` to `if (existingRecord.length === 0)`
+
+## 3. Refactor — all 7 quality gates
+
+- [x] 3.1 `yarn vitest run tests/integration/db/queries/common.test.ts` — tests still green
+- [x] 3.2 `yarn tsc` — zero TypeScript errors
+- [x] 3.3 `yarn format:check` — Prettier clean (only pre-existing unrelated warnings; neither changed file listed)
+- [x] 3.4 Anti-pattern review — AP-P0-2 resolved; no new anti-patterns introduced
+- [x] 3.5 SOLID review — change itself is clean; pre-existing DIP/SRP concerns noted but out of scope for this fix
+- [x] 3.6 Documentation review — one WHY comment added; comments do not outnumber code lines
+- [x] 3.7 Project conventions — test in `tests/` Vitest, named `*.test.ts`, setup imported via `"../setup"`
+- [x] 3.8 `yarn test:run2` — 45/45 passed, no regressions
+
+## 4. Archive
+
+- [ ] 4.1 Run `opsx:archive` on this branch before raising the PR

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -68,5 +68,14 @@ rules:
   tasks:
     - TDD order is mandatory: write the failing Vitest test first, then implement, then refactor.
     - Each task must be independently runnable (yarn vitest run path/to/test.ts).
-    - Include yarn tsc and yarn format:check as explicit final tasks before done.
+    - Test files use *.test.ts naming — never *_test.ts.
     - If a DB migration is involved, yarn dbsync is a task — never drizzle-kit push.
+    - The refactor section MUST include all 7 quality gates as explicit tasks in this order:
+        1. yarn vitest run <test-file>          — tests still green after refactor
+        2. yarn tsc                             — zero TypeScript errors
+        3. yarn format:check                   — Prettier clean (run yarn format to fix)
+        4. Anti-pattern review                 — check .github/skills/anti-pattern-check.md
+        5. SOLID review                        — invoke solid-reviewer agent
+        6. Documentation review               — comments explain WHY not WHAT; balance rule applies
+        7. Project conventions review         — check .github/copilot-instructions.md
+    - Final task after all 7 gates pass: run opsx:archive on the same branch before raising the PR.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -39,6 +39,9 @@ context: |
   - DO NOT use node:test. app/backend.server/models/*_test.ts files are orphaned — do not extend them.
   - New tests go under tests/ using Vitest. PGlite setup: tests/integration/db/setup.ts.
   - createTestBackendContext() constructs test contexts. See tests/integration/db/ for patterns.
+  - Test file naming: always *.test.ts (e.g. common.test.ts) — never *_test.ts.
+  - Setup import path: `import "./setup"` for files directly in tests/integration/db/;
+    `import "../setup"` for files one level deeper (e.g. tests/integration/db/queries/).
 
   Critical anti-patterns: see .github/skills/anti-pattern-check.md — never reproduce any item listed there.
 

--- a/openspec/specs/delete-by-id-correct-existence-check/spec.md
+++ b/openspec/specs/delete-by-id-correct-existence-check/spec.md
@@ -1,0 +1,36 @@
+## Requirements
+
+### Requirement: deleteByIdForStringId throws when record does not exist
+`deleteByIdForStringId` in `app/backend.server/models/common.ts` SHALL throw an `Error`
+when no row with the given `id` exists in the target table. The error MUST be thrown from
+within the transaction before any delete is attempted.
+
+#### Scenario: Delete is called with an ID that does not exist in the table
+- **WHEN** `deleteByIdForStringId` is called with a string ID that has no matching row in
+  the target table
+- **THEN** the function SHALL throw an `Error` (reject the returned Promise)
+
+### Requirement: deleteByIdForStringId deletes the row when it exists
+`deleteByIdForStringId` in `app/backend.server/models/common.ts` SHALL delete the matching
+row and resolve without error when a row with the given `id` exists in the target table.
+
+#### Scenario: Delete is called with an ID that exists in the table
+- **WHEN** `deleteByIdForStringId` is called with a string ID that has a matching row in
+  the target table
+- **THEN** the function SHALL resolve without error
+- **AND** the row with that ID SHALL no longer exist in the table after the call
+
+### Requirement: Callers of deleteByIdForStringId require no changes
+All five direct callers of `deleteByIdForStringId` (`organizationDeleteById`,
+`nonecoLossesDeleteById`, `deleteRecordsDeleteById`, `disRecSectorsDeleteById`,
+`assetDeleteById`) SHALL continue to compile and behave correctly without modification.
+
+#### Scenario: Caller invokes deleteByIdForStringId for a row that exists
+- **WHEN** a caller such as `organizationDeleteById` calls `deleteByIdForStringId` with the
+  ID of an existing row
+- **THEN** the caller SHALL receive a resolved Promise (no error thrown)
+
+#### Scenario: Caller invokes deleteByIdForStringId for a row that does not exist
+- **WHEN** a caller such as `organizationDeleteById` calls `deleteByIdForStringId` with an
+  ID that has no matching row
+- **THEN** the caller SHALL receive a rejected Promise (an Error is thrown)

--- a/tests/integration/db/queries/common.test.ts
+++ b/tests/integration/db/queries/common.test.ts
@@ -1,0 +1,33 @@
+import "../setup";
+import { eq } from "drizzle-orm";
+import { describe, it, expect } from "vitest";
+import { dr } from "~/db.server";
+import { deleteByIdForStringId } from "~/backend.server/models/common";
+import { userTable } from "~/drizzle/schema";
+
+describe("deleteByIdForStringId", () => {
+	it("throws when the record does not exist", async () => {
+		const nonExistentId = crypto.randomUUID();
+		await expect(
+			deleteByIdForStringId(nonExistentId, userTable),
+		).rejects.toThrow();
+	});
+
+	it("deletes the row and resolves when the record exists", async () => {
+		const userId = crypto.randomUUID();
+		await dr.insert(userTable).values({
+			id: userId,
+			email: `test-${userId}@example.com`,
+		});
+
+		await expect(
+			deleteByIdForStringId(userId, userTable),
+		).resolves.not.toThrow();
+
+		const remaining = await dr
+			.select({ id: userTable.id })
+			.from(userTable)
+			.where(eq(userTable.id, userId));
+		expect(remaining).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes P0-02: `deleteByIdForStringId` in `app/backend.server/models/common.ts` was missing `await` on the existence check, causing the guard to never fire and deletes silently succeed even when the target record did not exist.
- Validates and improves the SDD+TDD agent pipeline (spec-writer, tdd-test-writer, sdd-implementer) through an end-to-end test run with GitHub Copilot.

## Updates

### Bug fix (P0-2)
- `app/backend.server/models/common.ts` - added `await` + `.execute()` to the `tx.select()` call; corrected the guard from `if (!existingRecord)` to `if (existingRecord.length === 0)`
- `tests/integration/db/queries/common.test.ts` - new PGlite integration test covering both throw-on-missing and delete-on-exists scenarios
- `openspec/changes/fix-delete-by-id-missing-await/` - archived to `openspec/changes/archive/` after implementation.

### Agent and workflow improvements (from Copilot validation run)
- `spec-writer.agent.md` - added hard role boundary ("do not touch source files"), made OpenSpec CLI commands mandatory first actions, added done condition
- `sdd-implementer.agent.md` - added guardrails distinguishing additive vs destructive actions; explicit delegation to `tdd-test-writer` before Green phase; `opsx:archive` added to done criteria
- `tdd-test-writer.agent.md` - added `*.test.ts` naming rule and setup import path
- `openspec/config.yaml` - added test naming convention; expanded `tasks` rules to require all 7 refactor gates and `opsx:archive` in every generated `tasks.md`
- `_docs/workflows/openspec.md` - added `opsx:explore` as Step 0; updated commands from `npx` to `openspec`

## Test plan
- [x] `yarn vitest run tests/integration/db/queries/common.test.ts` - 2/2 pass
- [x] `yarn test:run2` - 45/45 pass, no regressions
- [x] `yarn tsc` - zero errors
- [x] Agent pipeline validated end-to-end with GitHub Copilot (spec-writer -> sdd-implementer -> tdd-test-writer -> 7 gates -> archive)